### PR TITLE
Update ctest.h to fix warning on gcc

### DIFF
--- a/inc/ctest.h
+++ b/inc/ctest.h
@@ -38,7 +38,7 @@ C_LINKAGE_PREFIX int snprintf(char * s, size_t n, const char * format, ...);
 #endif
 #endif
 
-#if _MSC_VER <= 1500
+#if defined _MSC_VER && _MSC_VER <= 1500
 #pragma warning(disable: 4510 4512 4610) /* MSC 1500 (VS2008) incorrectly fires this */
 #endif
 


### PR DESCRIPTION
The existing expression resolves to true on gcc