### PR TITLE
[MrBot] Add guidance: prefer enum type in ASSERT_ARE_EQUAL

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,26 @@ CTEST_TO_STRING(my_type, MY_STRUCT, string, bufferSize, value)
 - **Force Fail**: `CTEST_ASSERT_FAIL(message...)`
 - **Optional Messages**: All assertions support `printf`-style format strings as final arguments
 
+#### Prefer the actual enum type when asserting enum values
+When asserting a value whose declared type is an enum, always pass the enum type as the first argument to 
+`ASSERT_ARE_EQUAL`. Do not cast to `int` just to make the assert compile:
+
+```c
+// BAD - loses type information, no symbolic name on failure
+ASSERT_ARE_EQUAL(int, (int)MY_RESULT_OK, (int)result);
+
+// GOOD - prints the enum value names on failure
+ASSERT_ARE_EQUAL(MY_RESULT, MY_RESULT_OK, result);
+```
+
+Use  `TEST_DEFINE_ENUM_TYPE` to define the enum for the test.
+```c
+TEST_DEFINE_ENUM_TYPE(MY_RESULT, MY_RESULT_VALUES);
+```
+
+The enum-typed assert prints the symbolic name of both expected and actual values (e.g. `MY_RESULT_TIMED_OUT` instead of `1`), which is far more useful when diagnosing failures from CI logs.
+
+
 ### Parameterized Tests
 `CTEST_PARAMETERIZED_TEST_FUNCTION` generates multiple `CTEST_FUNCTION` wrappers from a single test body:
 ```c


### PR DESCRIPTION
Adds a note to `.github/copilot-instructions.md` instructing contributors to pass the actual enum type to `ASSERT_ARE_EQUAL` rather than casting to int, so failure messages print symbolic enum names instead of raw integers.