### PR TITLE
Remove CTEST_RUN_TEST_SUITE_WITH_LEAK_CHECK_RETRIES back-compat alias

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,9 +45,7 @@ CTEST_RUN_TEST_SUITE(SuiteName, failedTests);
 // With test name filter (run only a specific test)
 CTEST_RUN_TEST_SUITE(SuiteName, failedTests, "specific_test_name");
 
-// Leak detection runs once at process exit under VLD; CTEST_RUN_TEST_SUITE_WITH_LEAK_CHECK_RETRIES
-// is a backward-compatible alias for CTEST_RUN_TEST_SUITE (retries were removed)
-CTEST_RUN_TEST_SUITE_WITH_LEAK_CHECK_RETRIES(SuiteName);
+// Leak detection runs once at process exit under VLD (the leak-check-retries variant was removed)
 ```
 
 ## Project-Specific Patterns
@@ -111,7 +109,6 @@ CTEST_RUN_TEST_SUITE(SuiteName, failedTests, "specific_test_name");
 ```
 - When the filter is provided and non-empty, only the test whose function name matches exactly will execute.
 - Skipped tests are reported in the summary (e.g. `3 skipped by filter`).
-- Also supported via `CTEST_RUN_TEST_SUITE_WITH_LEAK_CHECK_RETRIES`, which is now a backward-compatible alias for `CTEST_RUN_TEST_SUITE`.
 
 ### Windows-Specific Features
 - **VLD Integration**: Automatic memory leak detection with `USE_VLD` compilation flag

--- a/doc/ctest_user_manual.md
+++ b/doc/ctest_user_manual.md
@@ -166,7 +166,7 @@ This works by capturing the number of live allocations when the run starts and c
 CTEST_RUN_TEST_SUITE(suiteName{,failedTestCount}{,testNameFilter});
 ```
 
-Because the check is deferred to process exit, allocations that are cleaned up asynchronously after a test ends are no longer misreported, so no retry mechanism is needed. `CTEST_RUN_TEST_SUITE_WITH_LEAK_CHECK_RETRIES` is retained as a backward-compatible alias for `CTEST_RUN_TEST_SUITE`.
+Because the check is deferred to process exit, allocations that are cleaned up asynchronously after a test ends are no longer misreported, so no retry mechanism is needed.
 
 ## Fixtures
 

--- a/inc/ctest.h
+++ b/inc/ctest.h
@@ -317,11 +317,6 @@ do \
     MU_IF(MU_DIV2(MU_COUNT_ARG(__VA_ARGS__)),CTEST_ACCUMULATE_FAILED(__VA_ARGS__),) RunTests(&MU_C2(TestListHead_, FIRST_ARG(__VA_ARGS__)), MU_TOSTRING(FIRST_ARG(__VA_ARGS__)), CTEST_GET_THIRD_ARG(__VA_ARGS__)); \
 } while ((void)0,0)
 
-/* Leak-check retries were removed: the leak check now runs once at process exit (see
-   ctest_check_leaks_at_exit in ctest.c), which catches asynchronously cleaned-up allocations without
-   re-running tests. This macro is kept as a backward-compatible alias for CTEST_RUN_TEST_SUITE. */
-#define CTEST_RUN_TEST_SUITE_WITH_LEAK_CHECK_RETRIES(...) CTEST_RUN_TEST_SUITE(__VA_ARGS__)
-
 typedef char* char_ptr;
 typedef wchar_t* wchar_ptr;
 typedef void* void_ptr;


### PR DESCRIPTION
The leak check now runs once at process exit via the atexit handler, so the retries variant no longer differs from CTEST_RUN_TEST_SUITE. The macro had no remaining callers, so the alias is removed rather than retained. Updated the user manual and copilot-instructions accordingly.